### PR TITLE
Added unit abbreviations according to USPS...

### DIFF
--- a/streetaddress/addressconf.py
+++ b/streetaddress/addressconf.py
@@ -510,7 +510,7 @@ class Regexes(object):
 	direct = re.compile('|'.join(Directions.DIRECTIONAL.keys()) + '|' + '|'.join([(''.join([n+'\\.' for n in v])+'|'+v) for v in sorted(Directions.DIRECTIONAL.values(), key=len, reverse=True)]), re.IGNORECASE)
 	zip_code = re.compile(r'(\d{5})(?:-(\d{4}))?')
 	corner = re.compile(r'(?:\band\b|\bat\b|&|\@)', re.IGNORECASE)
-	unit = re.compile(r'(?:(su?i?te|p\W*[om]\W*b(?:ox)?|dept|apt|apartment|ro*m|fl|unit|box)\W+|\#\W*)([\w-]+)', re.IGNORECASE)
+	unit = re.compile(r'(?:(su?i?te|p\W*[om]\W*b(?:ox)?|dept|apt|trlr|lot|rm|ste|apartment|ro*m|fl|unit|box)\W+|\#\W*)([\w-]+)', re.IGNORECASE)
 	street = re.compile(r'(?:(?:({0})\W+({1})\b)|(?:({0})\W+)?(?:([^,]+)(?:[^\w,]+({1})\b)(?:[^\w,]+({0})\b)?|([^,]*\d)({0})\b|([^,]+?)(?:[^\w,]+({1})\b)?(?:[^\w,]+({0})\b)?))'.format(direct.pattern,street_type.pattern), re.IGNORECASE)
 	place = re.compile(r'(?:([^\d,]+?)\W+(${0})\W*)?(?:{1})?'.format(state.pattern,zip_code.pattern), re.IGNORECASE)
 	address = re.compile(r'\A\W*({0})\W*(?:{1}\W*)?{2}\W+(?:{3}\W+)?{4}\W*\Z'.format(number.pattern,fraction.pattern,street.pattern,unit.pattern,place.pattern), re.IGNORECASE)


### PR DESCRIPTION
... official reference (code works better for TX streets, now) found here: https://www.usps.com/send/official-abbreviations.htm

Without these minor additions, trailers (TRLR) and lots (LOT) are parsed incorrectly.
